### PR TITLE
Separate coach and solo user experiences

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -38,8 +38,14 @@ const AppLayout: React.FC = () => {
     if (!loading && session && profile) {
       const currentPath = location.pathname;
       if (currentPath === '/' || currentPath === '/home') {
-        console.log('Redirecting to dashboard from:', currentPath);
-        navigate('/dashboard', { replace: true });
+        // Role-based default routing
+        if (profile.role === 'coach') {
+          console.log('Redirecting coach to athletes from:', currentPath);
+          navigate('/athletes', { replace: true });
+        } else {
+          console.log('Redirecting solo user to dashboard from:', currentPath);
+          navigate('/dashboard', { replace: true });
+        }
       }
     }
   }, [profile, loading, session, navigate, location.pathname]);

--- a/src/hooks/useRequireRole.ts
+++ b/src/hooks/useRequireRole.ts
@@ -1,0 +1,44 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '@/contexts/AuthContext';
+
+/**
+ * Hook that redirects users who don't have the required role
+ * Can be used as an HOC to protect role-specific pages
+ * 
+ * @param requiredRole - The role required to access the page
+ * @param redirectTo - Where to redirect if user doesn't have the role (defaults to /dashboard)
+ * 
+ * @example
+ * // Basic usage in a coach-only component:
+ * const MyCoachComponent = () => {
+ *   const hasAccess = useRequireRole('coach');
+ *   
+ *   if (!hasAccess) return null; // Will redirect automatically
+ *   
+ *   return <div>Coach-only content</div>;
+ * };
+ * 
+ * @example 
+ * // With custom redirect path:
+ * const hasAccess = useRequireRole('coach', '/unauthorized');
+ */
+export const useRequireRole = (
+  requiredRole: 'coach' | 'athlete' | 'solo',
+  redirectTo: string = '/dashboard'
+) => {
+  const { profile, loading } = useAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!loading && profile) {
+      if (profile.role !== requiredRole) {
+        console.log(`User role '${profile.role}' does not match required role '${requiredRole}', redirecting to ${redirectTo}`);
+        navigate(redirectTo, { replace: true });
+      }
+    }
+  }, [profile, loading, requiredRole, redirectTo, navigate]);
+
+  // Return whether the user has the required role
+  return !loading && profile?.role === requiredRole;
+};

--- a/src/pages/CoachRiskBoard.tsx
+++ b/src/pages/CoachRiskBoard.tsx
@@ -1,17 +1,17 @@
 
 import React from 'react';
-import { useAuth } from '@/contexts/AuthContext';
-import { AthleteModal } from '@/components/AthleteModal';
-import { Alert, AlertDescription } from '@/components/ui/alert';
-import { AlertTriangle } from 'lucide-react';
 import { useIsMobile } from '@/hooks/useBreakpoint';
 import { RiskBoardHeader } from '@/components/RiskBoardHeader';
 import { RiskBoardContent } from '@/components/RiskBoardContent';
 import { useRiskBoardData } from '@/hooks/useRiskBoardData';
 import { useAthleteModal } from '@/hooks/useAthleteModal';
+import { useRequireRole } from '@/hooks/useRequireRole';
+import { AthleteModal } from '@/components/AthleteModal';
 
 const CoachRiskBoard: React.FC = () => {
-  const { profile } = useAuth();
+  // Use the role guard hook - redirects if not coach
+  const hasAccess = useRequireRole('coach');
+  
   const isMobile = useIsMobile();
   const { riskBoardData, isLoading } = useRiskBoardData();
   const { 
@@ -21,15 +21,9 @@ const CoachRiskBoard: React.FC = () => {
     handleModalClose 
   } = useAthleteModal();
 
-  if (profile?.role !== 'coach') {
-    return (
-      <Alert>
-        <AlertTriangle className="h-4 w-4" />
-        <AlertDescription>
-          Access denied. This page is only available for coaches.
-        </AlertDescription>
-      </Alert>
-    );
+  // Don't render anything if user doesn't have access (will be redirected)
+  if (!hasAccess) {
+    return null;
   }
 
   return (

--- a/tests/roleGuard.spec.ts
+++ b/tests/roleGuard.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect } from '@playwright/test';
+
+// Demo account credentials - update these with actual test accounts
+const COACH_DEMO = {
+  email: 'coach-demo@example.com',
+  password: 'demo-password-123'
+};
+
+const SOLO_DEMO = {
+  email: 'solo-demo@example.com', 
+  password: 'demo-password-123'
+};
+
+test.describe('Role Guard Functionality', () => {
+  
+  test.describe('Coach Role Experience', () => {
+    test.beforeEach(async ({ page }) => {
+      // Login as coach
+      await page.goto('/login');
+      await page.fill('input[type="email"]', COACH_DEMO.email);
+      await page.fill('input[type="password"]', COACH_DEMO.password);
+      await page.click('button[type="submit"]');
+      await page.waitForURL(/\/athletes/); // Should redirect to athletes page
+    });
+
+    test('should redirect coach to /athletes by default', async ({ page }) => {
+      await page.goto('/');
+      await expect(page).toHaveURL(/\/athletes/);
+    });
+
+    test('should show coach-only navigation items', async ({ page }) => {
+      // Check that Athletes link is visible
+      await expect(page.locator('nav').getByText('Athletes')).toBeVisible();
+      
+      // Check that Risk Board link is visible
+      await expect(page.locator('nav').getByText('Risk Board')).toBeVisible();
+    });
+
+    test('should allow access to coach-only pages', async ({ page }) => {
+      // Test Athletes page access
+      await page.click('nav a[href="/athletes"]');
+      await expect(page).toHaveURL(/\/athletes/);
+      
+      // Test Risk Board page access
+      await page.click('nav a[href="/risk-board"]');
+      await expect(page).toHaveURL(/\/risk-board/);
+    });
+  });
+
+  test.describe('Solo Role Experience', () => {
+    test.beforeEach(async ({ page }) => {
+      // Login as solo user
+      await page.goto('/login');
+      await page.fill('input[type="email"]', SOLO_DEMO.email);
+      await page.fill('input[type="password"]', SOLO_DEMO.password);
+      await page.click('button[type="submit"]');
+      await page.waitForURL(/\/dashboard/); // Should redirect to dashboard
+    });
+
+    test('should redirect solo user to /dashboard by default', async ({ page }) => {
+      await page.goto('/');
+      await expect(page).toHaveURL(/\/dashboard/);
+    });
+
+    test('should NOT show coach-only navigation items', async ({ page }) => {
+      // Check that Athletes link is NOT visible
+      await expect(page.locator('nav').getByText('Athletes')).not.toBeVisible();
+      
+      // Check that Risk Board link is NOT visible
+      await expect(page.locator('nav').getByText('Risk Board')).not.toBeVisible();
+    });
+
+    test('should show solo-specific navigation items', async ({ page }) => {
+      // Check that Program link is visible (solo-only)
+      await expect(page.locator('nav').getByText('Program')).toBeVisible();
+    });
+
+    test('should be redirected away from coach-only pages', async ({ page }) => {
+      // Try to access Athletes page directly
+      await page.goto('/athletes');
+      await expect(page).toHaveURL(/\/dashboard/); // Should be redirected
+      
+      // Try to access Risk Board page directly
+      await page.goto('/risk-board');
+      await expect(page).toHaveURL(/\/dashboard/); // Should be redirected
+    });
+
+    test('should have access to solo-allowed pages', async ({ page }) => {
+      // Test Program page access
+      await page.click('nav a[href="/program"]');
+      await expect(page).toHaveURL(/\/program/);
+      
+      // Test Dashboard access
+      await page.click('nav a[href="/dashboard"]');
+      await expect(page).toHaveURL(/\/dashboard/);
+    });
+  });
+
+  test.describe('Common Navigation', () => {
+    test('both roles should have access to shared pages', async ({ page }) => {
+      // Test with coach account
+      await page.goto('/login');
+      await page.fill('input[type="email"]', COACH_DEMO.email);
+      await page.fill('input[type="password"]', COACH_DEMO.password);
+      await page.click('button[type="submit"]');
+      await page.waitForURL(/\/athletes/);
+      
+      // Test Chat access
+      await page.click('nav a[href="/chat"]');
+      await expect(page).toHaveURL(/\/chat/);
+      
+      // Test Settings access
+      await page.click('nav a[href="/settings"]');
+      await expect(page).toHaveURL(/\/settings/);
+    });
+  });
+});


### PR DESCRIPTION
Separate coach and solo user experiences with role-based routing and page access control.

This PR introduces a `useRequireRole` hook for protecting coach-only pages, adjusts default login redirects based on user role, and includes Cypress tests to validate the new behavior.