### PR TITLE
Add analytics edge function for dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -143,7 +143,7 @@
         "pg": "^8.16.3",
         "postcss": "^8.4.47",
         "tailwindcss": "^3.4.11",
-        "ts-jest": "^29.1.1",
+        "ts-jest": "^29.4.0",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.0.1",
         "vite": "^5.4.1"

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "pg": "^8.16.3",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.11",
-    "ts-jest": "^29.1.1",
+    "ts-jest": "^29.4.0",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1"

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -46,6 +46,9 @@ verify_jwt = true
 [functions.endWorkout]
 verify_jwt = true
 
+[functions.getAnalytics]
+verify_jwt = true
+
 # Cron job to run session reminders every 15 minutes
 # [functions.sessionReminders.schedule]
 # cron = "*/15 * * * *"

--- a/supabase/functions/getAnalytics/index.ts
+++ b/supabase/functions/getAnalytics/index.ts
@@ -1,0 +1,104 @@
+import { serve } from 'https://deno.land/std@0.193.0/http/server.ts'
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { corsHeaders } from '../_shared/cors.ts'
+
+serve(async (req) => {
+  // Handle CORS preflight requests
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    // Bootstrap Supabase client with service role
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
+      { 
+        global: { 
+          headers: { 
+            Authorization: req.headers.get('Authorization')! 
+          } 
+        } 
+      }
+    )
+
+    // Auth guard - must be logged in
+    const {
+      data: { user },
+      error: authError
+    } = await supabase.auth.getUser()
+    
+    if (authError || !user) {
+      console.error('Auth error:', authError)
+      return new Response(
+        JSON.stringify({ error: 'Unauthorized' }), 
+        { 
+          status: 401, 
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' } 
+        }
+      )
+    }
+
+    // 1. Query tonnage data
+    const { data: tonnageData, error: tonnageError } = await supabase
+      .rpc('get_tonnage_data', { user_id: user.id })
+
+    if (tonnageError) {
+      console.error('Tonnage query error:', tonnageError)
+      throw tonnageError
+    }
+
+    // 2. Query e1RM curves data
+    const { data: e1rmData, error: e1rmError } = await supabase
+      .rpc('get_e1rm_data', { user_id: user.id })
+
+    if (e1rmError) {
+      console.error('e1RM query error:', e1rmError)
+      throw e1rmError
+    }
+
+    // 3. Query velocity-fatigue data
+    const { data: velocityFatigueData, error: velocityFatigueError } = await supabase
+      .rpc('get_velocity_fatigue_data', { user_id: user.id })
+
+    if (velocityFatigueError) {
+      console.error('Velocity-fatigue query error:', velocityFatigueError)
+      throw velocityFatigueError
+    }
+
+    // 4. Query muscle load data
+    const { data: muscleLoadData, error: muscleLoadError } = await supabase
+      .from('muscle_load_daily')
+      .select('*')
+      .eq('user_id', user.id)
+      .order('date')
+
+    if (muscleLoadError) {
+      console.error('Muscle load query error:', muscleLoadError)
+      throw muscleLoadError
+    }
+
+    // Return all four data series
+    return new Response(
+      JSON.stringify({
+        tonnage: tonnageData || [],
+        e1rmCurve: e1rmData || [],
+        velocityFatigue: velocityFatigueData || [],
+        muscleLoad: muscleLoadData || []
+      }),
+      { 
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' } 
+      }
+    )
+
+  } catch (error) {
+    console.error('getAnalytics error:', error)
+    return new Response(
+      JSON.stringify({ error: error.message }),
+      { 
+        status: 500,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' }
+      }
+    )
+  }
+})

--- a/supabase/migrations/20250108_analytics_functions.sql
+++ b/supabase/migrations/20250108_analytics_functions.sql
@@ -1,0 +1,81 @@
+-- Analytics Functions Migration
+-- Creates SQL functions for getAnalytics Edge Function
+
+BEGIN;
+
+-- 1. Function to get tonnage data (daily sum of weight × reps)
+CREATE OR REPLACE FUNCTION public.get_tonnage_data(user_id UUID)
+RETURNS TABLE (
+  date DATE,
+  tonnage NUMERIC
+)
+LANGUAGE SQL
+SECURITY DEFINER
+AS $$
+  SELECT 
+    date_trunc('day', ws.created_at)::date AS date,
+    SUM(ws.weight * ws.reps) AS tonnage
+  FROM workout_sets ws
+  JOIN workout_sessions s ON s.id = ws.session_id
+  WHERE s.user_id = user_id
+  GROUP BY 1
+  ORDER BY 1;
+$$;
+
+-- 2. Function to get e1RM curve data
+CREATE OR REPLACE FUNCTION public.get_e1rm_data(user_id UUID)
+RETURNS TABLE (
+  exercise TEXT,
+  date DATE,
+  e1rm NUMERIC
+)
+LANGUAGE SQL
+SECURITY DEFINER
+AS $$
+  SELECT 
+    exercise,
+    achieved_at::date AS date,
+    value AS e1rm
+  FROM pr_records
+  WHERE user_id = get_e1rm_data.user_id 
+    AND type = '1rm'
+  ORDER BY date;
+$$;
+
+-- 3. Function to get velocity-fatigue data
+-- Note: Since load_percent is in planned sessions but velocity is in workout_sets,
+-- we'll compute a simplified version using workout data only for now
+CREATE OR REPLACE FUNCTION public.get_velocity_fatigue_data(user_id UUID)
+RETURNS TABLE (
+  date DATE,
+  avg_velocity NUMERIC,
+  max_load NUMERIC
+)
+LANGUAGE SQL
+SECURITY DEFINER
+AS $$
+  WITH daily AS (
+    SELECT
+      date_trunc('day', ws.created_at)::date AS date,
+      AVG(ws.velocity) AS avg_velocity,
+      MAX(ws.weight) AS max_load
+    FROM workout_sets ws
+    JOIN workout_sessions s ON s.id = ws.session_id
+    WHERE s.user_id = get_velocity_fatigue_data.user_id
+      AND ws.velocity IS NOT NULL
+    GROUP BY 1
+  )
+  SELECT 
+    date, 
+    avg_velocity, 
+    max_load AS max_load
+  FROM daily
+  ORDER BY date;
+$$;
+
+-- Grant execute permissions to authenticated users
+GRANT EXECUTE ON FUNCTION public.get_tonnage_data(UUID) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_e1rm_data(UUID) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_velocity_fatigue_data(UUID) TO authenticated;
+
+COMMIT;

--- a/tests/getAnalytics.test.ts
+++ b/tests/getAnalytics.test.ts
@@ -1,0 +1,157 @@
+/**
+ * @jest-environment node
+ */
+describe('getAnalytics Function Tests', () => {
+  // Mock database responses for testing without requiring actual database connection
+
+  test('tonnage query logic is correct', () => {
+    // Test the SQL logic for tonnage calculation
+    // Expected: Daily sum of weight × reps from workout_sets
+    
+    // Mock data representing the query result
+    const mockWorkoutSets = [
+      { weight: 100, reps: 5, date: '2024-01-15' }, // 500
+      { weight: 80, reps: 8, date: '2024-01-15' },  // 640
+      { weight: 110, reps: 4, date: '2024-01-16' }, // 440
+      { weight: 85, reps: 6, date: '2024-01-16' }   // 510
+    ];
+    
+    // Calculate tonnage per day (simulating the SQL GROUP BY)
+    const tonnageByDay = mockWorkoutSets.reduce((acc, set) => {
+      const tonnage = set.weight * set.reps;
+      acc[set.date] = (acc[set.date] || 0) + tonnage;
+      return acc;
+    }, {} as Record<string, number>);
+    
+    expect(tonnageByDay['2024-01-15']).toBe(1140); // 500 + 640
+    expect(tonnageByDay['2024-01-16']).toBe(950);  // 440 + 510
+  });
+
+  test('e1RM query logic is correct', () => {
+    // Test the SQL logic for e1RM data retrieval
+    // Expected: PR records filtered by type='1rm', ordered by date
+    
+    // Mock PR records data
+    const mockPRRecords = [
+      { exercise: 'Squat', type: '1rm', value: 150.5, achieved_at: '2024-01-15' },
+      { exercise: 'Bench Press', type: '1rm', value: 120.0, achieved_at: '2024-01-15' },
+      { exercise: 'Squat', type: '1rm', value: 155.0, achieved_at: '2024-01-16' },
+      { exercise: 'Squat', type: '3rm', value: 140.0, achieved_at: '2024-01-15' } // Should be filtered out
+    ];
+    
+    // Filter for only 1RM records and sort by date
+    const e1rmRecords = mockPRRecords
+      .filter(record => record.type === '1rm')
+      .sort((a, b) => a.achieved_at.localeCompare(b.achieved_at));
+    
+    expect(e1rmRecords).toHaveLength(3);
+    expect(e1rmRecords[0].exercise).toBe('Squat');
+    expect(e1rmRecords[0].value).toBe(150.5);
+    expect(e1rmRecords[1].exercise).toBe('Bench Press');
+    expect(e1rmRecords[1].value).toBe(120.0);
+    expect(e1rmRecords[2].exercise).toBe('Squat');
+    expect(e1rmRecords[2].value).toBe(155.0);
+  });
+
+  test('velocity-fatigue query logic is correct', () => {
+    // Test the SQL logic for velocity-fatigue analysis
+    // Expected: Daily average velocity and max load from workout_sets
+    
+    // Mock workout sets with velocity data
+    const mockWorkoutSets = [
+      { velocity: 0.8, weight: 100, date: '2024-01-15' },
+      { velocity: 0.9, weight: 95, date: '2024-01-15' },
+      { velocity: 0.7, weight: 110, date: '2024-01-16' },
+      { velocity: 0.8, weight: 105, date: '2024-01-16' },
+      { velocity: null, weight: 90, date: '2024-01-15' } // Should be filtered out
+    ];
+    
+    // Group by date and calculate averages (simulating the SQL GROUP BY)
+    const dailyData = mockWorkoutSets
+      .filter(set => set.velocity !== null) // Filter out null velocities
+      .reduce((acc, set) => {
+        if (!acc[set.date]) {
+          acc[set.date] = { velocities: [], weights: [] };
+        }
+        acc[set.date].velocities.push(set.velocity);
+        acc[set.date].weights.push(set.weight);
+        return acc;
+      }, {} as Record<string, { velocities: number[], weights: number[] }>);
+    
+    // Calculate final metrics
+    const results = Object.entries(dailyData).map(([date, data]) => ({
+      date,
+      avg_velocity: data.velocities.reduce((sum, v) => sum + v, 0) / data.velocities.length,
+      max_load: Math.max(...data.weights)
+    }));
+    
+    expect(results).toHaveLength(2);
+    
+    const day1 = results.find(r => r.date === '2024-01-15');
+    expect(day1?.avg_velocity).toBeCloseTo(0.85); // (0.8 + 0.9) / 2
+    expect(day1?.max_load).toBe(100);
+    
+    const day2 = results.find(r => r.date === '2024-01-16');
+    expect(day2?.avg_velocity).toBeCloseTo(0.75); // (0.7 + 0.8) / 2
+    expect(day2?.max_load).toBe(110);
+  });
+
+  test('muscle load data structure is correct', () => {
+    // Test the muscle load daily data structure
+    // Expected: User-specific muscle load scores by date and muscle
+    
+    // Mock muscle load data
+    const mockMuscleLoadData = [
+      { user_id: 'user1', date: '2024-01-15', muscle: 'quadriceps', load_score: 75.5 },
+      { user_id: 'user1', date: '2024-01-15', muscle: 'chest', load_score: 65.0 },
+      { user_id: 'user1', date: '2024-01-16', muscle: 'quadriceps', load_score: 80.0 },
+      { user_id: 'user2', date: '2024-01-15', muscle: 'chest', load_score: 70.0 } // Different user
+    ];
+    
+    // Filter for specific user and sort (simulating the SQL query)
+    const userMuscleData = mockMuscleLoadData
+      .filter(record => record.user_id === 'user1')
+      .sort((a, b) => a.date.localeCompare(b.date) || a.muscle.localeCompare(b.muscle));
+    
+    expect(userMuscleData).toHaveLength(3);
+    expect(userMuscleData[0].muscle).toBe('chest');
+    expect(userMuscleData[0].load_score).toBe(65.0);
+    expect(userMuscleData[1].muscle).toBe('quadriceps');
+    expect(userMuscleData[1].load_score).toBe(75.5);
+    expect(userMuscleData[2].muscle).toBe('quadriceps');
+    expect(userMuscleData[2].load_score).toBe(80.0);
+  });
+
+  test('getAnalytics function structure', () => {
+    // Test that the expected return structure is valid
+    const mockAnalyticsResponse = {
+      tonnage: [
+        { date: '2024-01-15', tonnage: 1140 },
+        { date: '2024-01-16', tonnage: 950 }
+      ],
+      e1rmCurve: [
+        { exercise: 'Squat', date: '2024-01-15', e1rm: 150.5 },
+        { exercise: 'Bench Press', date: '2024-01-15', e1rm: 120.0 }
+      ],
+      velocityFatigue: [
+        { date: '2024-01-15', avg_velocity: 0.85, max_load: 100 },
+        { date: '2024-01-16', avg_velocity: 0.75, max_load: 110 }
+      ],
+      muscleLoad: [
+        { user_id: 'user1', date: '2024-01-15', muscle: 'quadriceps', load_score: 75.5 }
+      ]
+    };
+    
+    // Verify the response has all required properties
+    expect(mockAnalyticsResponse).toHaveProperty('tonnage');
+    expect(mockAnalyticsResponse).toHaveProperty('e1rmCurve');
+    expect(mockAnalyticsResponse).toHaveProperty('velocityFatigue');
+    expect(mockAnalyticsResponse).toHaveProperty('muscleLoad');
+    
+    // Verify data structure
+    expect(Array.isArray(mockAnalyticsResponse.tonnage)).toBe(true);
+    expect(Array.isArray(mockAnalyticsResponse.e1rmCurve)).toBe(true);
+    expect(Array.isArray(mockAnalyticsResponse.velocityFatigue)).toBe(true);
+    expect(Array.isArray(mockAnalyticsResponse.muscleLoad)).toBe(true);
+  });
+});


### PR DESCRIPTION
Add `getAnalytics` Edge Function to provide aggregated data for the analytics dashboard.

The `velocity-fatigue` query in the `get_velocity_fatigue_data` SQL function uses `MAX(ws.weight)` for `max_load` instead of `MAX(s.load_percent)` as originally specified. This adjustment was made because `load_percent` is stored in the `session` table (planned sessions), while `workout_sets` (actual workout data) links to `workout_sessions`, making a direct join for `load_percent` impractical without further schema changes or complex logic to map logged workouts to planned sessions. The current implementation provides a simplified velocity vs. load metric based on actual workout weight.

---

[Open in Web](https://cursor.com/agents?id=bc-1d5cdbe8-5f2b-4660-a443-d961c1746291) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-1d5cdbe8-5f2b-4660-a443-d961c1746291) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)