### PR TITLE
Update imports to use @catalyft/core

### DIFF
--- a/src/components/training-plan/AriaGenerateWizard.tsx
+++ b/src/components/training-plan/AriaGenerateWizard.tsx
@@ -7,7 +7,7 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Checkbox } from '@/components/ui/checkbox';
-import { generateProgramWithAria } from '../../../packages/core/dist/api/aria-program';
+import { generateProgramWithAria } from '@catalyft/core';
 import { Loader2, Sparkles } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 

--- a/src/features/dashboard/InsightStack.tsx
+++ b/src/features/dashboard/InsightStack.tsx
@@ -3,7 +3,7 @@ import { View, Text, StyleSheet } from 'react-native';
 import DeckSwiper from 'react-native-deck-swiper';
 import { motion } from 'framer-motion';
 import { useInsights, Insight } from '@/hooks/useInsights';
-import { saveInsight } from '../../../packages/core/dist/api/insights';
+import { saveInsight } from '@catalyft/core';
 import { Brain, Target, TrendingUp, Moon, Activity, Dumbbell, AlertTriangle } from 'lucide-react';
 import { toast } from 'sonner';
 

--- a/src/pages/onboarding/SoloWizard.tsx
+++ b/src/pages/onboarding/SoloWizard.tsx
@@ -7,7 +7,7 @@ import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Badge } from '@/components/ui/badge';
 import { CheckCircle, Target, User, Dumbbell, Sparkles, Loader2 } from 'lucide-react';
-import { generateProgramWithAria } from '../../../packages/core/dist/api/aria-program';
+import { generateProgramWithAria } from '@catalyft/core';
 import { useAuth } from '@/contexts/AuthContext';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';

--- a/src/pages/onboarding/__tests__/SoloWizard.test.tsx
+++ b/src/pages/onboarding/__tests__/SoloWizard.test.tsx
@@ -4,10 +4,10 @@ import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { SoloWizard } from '../SoloWizard';
 import { AuthProvider } from '@/contexts/AuthContext';
-import * as ariaProgram from '../../../../packages/core/dist/api/aria-program';
+import * as ariaProgram from '@catalyft/core';
 
 // Mock the API
-jest.mock('../../../../packages/core/dist/api/aria-program');
+jest.mock('@catalyft/core');
 const mockGenerateProgram = jest.fn();
 (ariaProgram.generateProgramWithAria as jest.Mock) = mockGenerateProgram;
 

--- a/stories/Dashboard/InsightStack.story.tsx
+++ b/stories/Dashboard/InsightStack.story.tsx
@@ -4,7 +4,7 @@ import { useInsights } from '@/hooks/useInsights';
 
 // Mock the hooks and APIs
 jest.mock('@/hooks/useInsights');
-jest.mock('../../packages/core/dist/api/insights');
+jest.mock('@catalyft/core');
 jest.mock('sonner', () => ({
   toast: {
     success: jest.fn(),


### PR DESCRIPTION
Update application imports to use `@catalyft/core` for shared functionality.

The migration involved updating numerous import paths across the main application, test files, and story files. Persistent build failures, primarily "Rollup failed to resolve import '@catalyft/core/api'", were debugged by systematically clearing caches, verifying package exports, and ensuring all references (including those in test/story mocks) were updated to consistently import from the main `@catalyft/core` package.

---

[Open in Web](https://cursor.com/agents?id=bc-a7c55006-c531-4cb6-a262-0799b0d75f79) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-a7c55006-c531-4cb6-a262-0799b0d75f79) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)