### PR TITLE
Enable workspaces and ts path mapping

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,5 +25,13 @@ export default tseslint.config(
       ],
       "@typescript-eslint/no-unused-vars": "off",
     },
+    settings: {
+      "import/resolver": {
+        "typescript": {
+          "alwaysTryTypes": true,
+          "project": "./tsconfig.json"
+        }
+      }
+    },
   }
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
       "name": "vite_react_shadcn_ts",
       "version": "0.0.0",
       "hasInstallScript": true,
+      "workspaces": [
+        "packages/*",
+        "apps/*"
+      ],
       "dependencies": {
         "@capacitor-community/sqlite": "^7.0.1",
         "@capacitor/android": "^7.4.2",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "workspaces": ["packages/*", "apps/*"],
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,9 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@catalyft/core": ["packages/core/src"],
+      "@catalyft/core/*": ["packages/core/src/*"]
     },
     "noImplicitAny": false,
     "noUnusedParameters": false,


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Enable Yarn/NPM workspaces and TypeScript path mapping to resolve `@catalyft/core` imports properly.

---

[Open in Web](https://cursor.com/agents?id=bc-f8e8f652-1eff-4096-897f-d8c4e04a4d0a) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-f8e8f652-1eff-4096-897f-d8c4e04a4d0a) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)