### PR TITLE
Separate core tests in ci

### DIFF
--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -13,8 +13,31 @@ permissions:
   contents: read
 
 jobs:
+  test-core:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: npm
+        
+    - name: Install dependencies
+      run: npm ci --legacy-peer-deps
+      
+    - name: Build core package
+      run: npm run build --workspace @catalyft/core
+      
+    - name: Test core package
+      run: npm test --workspace @catalyft/core
+
   health-check:
     runs-on: ubuntu-latest
+    needs: test-core  # Gate the main health check on core tests passing
     
     steps:
     - name: Checkout code

--- a/.github/workflows/test-core.yml
+++ b/.github/workflows/test-core.yml
@@ -1,0 +1,29 @@
+name: Test Core
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  test-core:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+          
+      - name: Install dependencies
+        run: npm install --legacy-peer-deps
+        
+      - name: Build core package
+        run: npm run build --workspace @catalyft/core
+        
+      - name: Test core package
+        run: npm test --workspace @catalyft/core


### PR DESCRIPTION
<pr_request_template>Introduce a dedicated CI job for `@catalyft/core` tests and gate the main build on its successful completion.

This ensures that any regressions in the core package are caught early and prevent the main build from proceeding, improving overall project stability.</pr_request_template>

---

[Open in Web](https://cursor.com/agents?id=bc-cc7a600b-43c8-4f38-b4e0-c7fbcb691927) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-cc7a600b-43c8-4f38-b4e0-c7fbcb691927) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)