### PR TITLE
Stub median app directory for migration

### DIFF
--- a/median-app/.gitignore
+++ b/median-app/.gitignore
@@ -1,0 +1,44 @@
+# Dependencies
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Production builds
+dist/
+build/
+
+# Median specific
+.median/
+
+# Mobile platform files
+android/
+ios/
+
+# Environment files
+.env
+.env.local
+.env.production
+.env.development
+
+# Logs
+*.log
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Temporary files
+*.tmp
+*.temp

--- a/median-app/README.md
+++ b/median-app/README.md
@@ -1,0 +1,38 @@
+# Median App
+
+This directory contains the stub setup for migrating our application to Median.
+
+## Overview
+
+Import `@catalyft/core` here and rebuild UI in Median.
+
+This is a placeholder directory for the upcoming Median project that will leverage our existing core functionality while providing a new mobile-focused user interface.
+
+## Setup Instructions
+
+To get started with the Median app:
+
+1. Navigate to the median-app directory:
+   ```bash
+   cd median-app
+   ```
+
+2. Initialize Median:
+   ```bash
+   npx median init
+   ```
+
+3. Install the core package:
+   ```bash
+   npm install @catalyft/core
+   ```
+
+## Next Steps
+
+- The core functionality is available through `@catalyft/core`
+- Implement the UI components using Median's framework
+- Leverage the existing API and business logic from the core package
+
+## Notes
+
+This is currently just scaffolding - no functional code has been implemented yet.

--- a/median-app/package.json
+++ b/median-app/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "median-app",
+  "version": "0.1.0",
+  "description": "Median migration app using @catalyft/core",
+  "main": "index.js",
+  "scripts": {
+    "dev": "median serve",
+    "build": "median build",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "@catalyft/core": "^0.1.0"
+  },
+  "devDependencies": {},
+  "keywords": [
+    "median",
+    "mobile",
+    "catalyft"
+  ],
+  "author": "CatalyFT Team",
+  "license": "UNLICENSED",
+  "private": true
+}


### PR DESCRIPTION
Create `median-app` stub directory to prepare for the upcoming Median project and integrate with `@catalyft/core`.

---

[Open in Web](https://cursor.com/agents?id=bc-4ad45dc0-411d-44fe-bf67-db8bb25f7d53) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-4ad45dc0-411d-44fe-bf67-db8bb25f7d53) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)