### PR TITLE
Migrate expo-camera to Median Bridge

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "embla-carousel-react": "^8.3.0",
     "expo": "^53.0.19",
     "expo-av": "^15.1.7",
-    "expo-camera": "^16.1.11",
     "expo-haptics": "^14.1.4",
     "expo-media-library": "^17.1.7",
     "file-saver": "^2.0.5",


### PR DESCRIPTION
Remove `expo-camera` dependency as it was found to be unused in the codebase.

The original task was to replace `expo-camera` with `window.Median` APIs. However, a comprehensive search revealed that `expo-camera` was listed as a dependency but never actually imported or used. All existing camera functionality in the project relies on browser APIs or MediaPipe. Therefore, the PR only removes the dead dependency.

---

[Open in Web](https://cursor.com/agents?id=bc-06935049-d6bd-4c05-b5c6-5c5423326ae6) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-06935049-d6bd-4c05-b5c6-5c5423326ae6) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)