### PR TITLE
Replace expo-haptics with median haptics

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,6 @@
     "embla-carousel-react": "^8.3.0",
     "expo": "^53.0.19",
     "expo-av": "^15.1.7",
-    "expo-haptics": "^14.1.4",
     "expo-media-library": "^17.1.7",
     "file-saver": "^2.0.5",
     "framer-motion": "^12.23.9",

--- a/src/pages/mobile/CalendarScreen.native.tsx
+++ b/src/pages/mobile/CalendarScreen.native.tsx
@@ -11,7 +11,8 @@ import {
 import { format, startOfMonth, endOfMonth, startOfWeek, endOfWeek, eachDayOfInterval, isSameDay, isToday, addWeeks, subWeeks } from 'date-fns';
 import { ChevronLeft, ChevronRight, Calendar as CalendarIcon, Dumbbell } from 'lucide-react-native';
 import DraggableFlatList, { RenderItemParams, ScaleDecorator } from 'react-native-draggable-flatlist';
-import * as Haptics from 'expo-haptics';
+// @ts-ignore
+const { Haptics } = window.Median;
 import { useCalendar } from '@/hooks/useCalendar';
 import { Session } from '@/types/training';
 import { rescheduleSession } from '@/lib/api/sessions';
@@ -227,7 +228,7 @@ const DraggableSessionItem = ({
   isActive 
 }: RenderItemParams<DraggableSessionData>) => {
   const handleLongPress = useCallback(() => {
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+    Haptics.impact('medium');
     drag();
   }, [drag]);
 
@@ -335,7 +336,7 @@ export const CalendarScreen: React.FC = () => {
     }
 
     try {
-      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+      Haptics.impact('light');
       
       const movedSession = data[to];
       const targetDate = calendarDays[to % calendarDays.length]?.date || movedSession.date;
@@ -371,7 +372,7 @@ export const CalendarScreen: React.FC = () => {
 
   const handleSessionLongPress = useCallback((session: Session, date: Date) => {
     setIsDragging(true);
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+    Haptics.impact('medium');
     
     Alert.alert(
       'Reschedule Session',


### PR DESCRIPTION
Replace `expo-haptics` with Median Bridge Haptics API to remove Expo-only dependencies.

---

[Open in Web](https://cursor.com/agents?id=bc-a743d239-c66f-4344-941e-e564b960b9e1) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-a743d239-c66f-4344-941e-e564b960b9e1) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)