### PR TITLE
Refactor solo training plan UI and screens

### DIFF
--- a/src/components/training-plan/MyProgramsScreen.tsx
+++ b/src/components/training-plan/MyProgramsScreen.tsx
@@ -8,7 +8,7 @@ import { EnhancedProgramBuilder } from '@/components/program-builder/EnhancedPro
 import { AriaGenerateWizard } from './AriaGenerateWizard';
 import { useNavigate } from 'react-router-dom';
 
-export const ProgramsTab: React.FC = () => {
+export const MyProgramsScreen: React.FC = () => {
   const { profile } = useAuth();
   const navigate = useNavigate();
   const [builderOpen, setBuilderOpen] = useState(false);
@@ -33,8 +33,8 @@ export const ProgramsTab: React.FC = () => {
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-2xl font-bold text-white">Training Programs</h2>
-          <p className="text-white/70">Create and manage your training programs</p>
+          <h2 className="text-2xl font-bold text-white">My Training Programs</h2>
+          <p className="text-white/70">Your personalized training programs</p>
         </div>
         <div className="flex gap-3">
           <Button 

--- a/src/components/training-plan/TrainingPlanTabs.tsx
+++ b/src/components/training-plan/TrainingPlanTabs.tsx
@@ -17,26 +17,13 @@ export const TrainingPlanTabs: React.FC = () => {
   return (
     <div className="mb-6">
       <Tabs value={currentTab} onValueChange={handleTabChange}>
-        <TabsList className="bg-white/5 backdrop-blur-lg border border-white/10 rounded-2xl p-1 grid w-full grid-cols-3">
+        <TabsList className="bg-white/5 backdrop-blur-lg border border-white/10 rounded-2xl p-1 grid w-full grid-cols-1">
           <TabsTrigger 
             value="programs" 
             className="text-white/70 data-[state=active]:bg-indigo-500/20 data-[state=active]:text-indigo-200 data-[state=active]:rounded-xl transition-all duration-200"
             data-variant="programs"
           >
-            Programs
-          </TabsTrigger>
-          <TabsTrigger 
-            value="instances" 
-            className="text-white/70 data-[state=active]:bg-indigo-500/20 data-[state=active]:text-indigo-200 data-[state=active]:rounded-xl transition-all duration-200"
-            data-variant="history"
-          >
-            History
-          </TabsTrigger>
-          <TabsTrigger 
-            value="library" 
-            className="text-white/70 data-[state=active]:bg-indigo-500/20 data-[state=active]:text-indigo-200 data-[state=active]:rounded-xl transition-all duration-200"
-          >
-            Library
+            My Programs
           </TabsTrigger>
         </TabsList>
       </Tabs>

--- a/src/components/training-plan/__tests__/TrainingPlanTabs.test.tsx
+++ b/src/components/training-plan/__tests__/TrainingPlanTabs.test.tsx
@@ -34,42 +34,33 @@ describe('TrainingPlanTabs', () => {
     mockNavigate.mockClear();
   });
 
-  it('should render all tab labels correctly', () => {
+  it('should render the My Programs tab label correctly', () => {
     renderWithProviders(<TrainingPlanTabs />);
     
-    expect(screen.getByText('Programs')).toBeInTheDocument();
-    expect(screen.getByText('History')).toBeInTheDocument();
-    expect(screen.getByText('Library')).toBeInTheDocument();
+    expect(screen.getByText('My Programs')).toBeInTheDocument();
   });
 
-  it('should have correct data attributes for tabs', () => {
+  it('should have correct data attributes for the Programs tab', () => {
     renderWithProviders(<TrainingPlanTabs />);
     
-    const programsTab = screen.getByText('Programs').closest('button');
-    const historyTab = screen.getByText('History').closest('button');
+    const programsTab = screen.getByText('My Programs').closest('button');
     
     expect(programsTab).toHaveAttribute('data-variant', 'programs');
-    expect(historyTab).toHaveAttribute('data-variant', 'history');
   });
 
-  it('should navigate to correct routes when tabs are clicked', async () => {
+  it('should show My Programs tab as active by default', () => {
     renderWithProviders(<TrainingPlanTabs />);
     
-    fireEvent.click(screen.getByText('History'));
-    await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('/training-plan/instances');
-    });
-
-    fireEvent.click(screen.getByText('Library'));
-    await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith('/training-plan/library');
-    });
-  });
-
-  it('should show Programs tab as active by default', () => {
-    renderWithProviders(<TrainingPlanTabs />);
-    
-    const programsTab = screen.getByText('Programs').closest('button');
+    const programsTab = screen.getByText('My Programs').closest('button');
     expect(programsTab).toHaveAttribute('data-state', 'active');
+  });
+
+  it('should navigate to programs route when tab is clicked', async () => {
+    renderWithProviders(<TrainingPlanTabs />);
+    
+    fireEvent.click(screen.getByText('My Programs'));
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith('/training-plan/programs');
+    });
   });
 });

--- a/src/pages/TrainingPlan.tsx
+++ b/src/pages/TrainingPlan.tsx
@@ -2,18 +2,14 @@
 import React from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import { TrainingPlanLayout } from '@/components/training-plan/TrainingPlanLayout';
-import { ProgramsTab } from '@/components/training-plan/ProgramsTab';
-import { ProgramInstancesTab } from '@/components/training-plan/ProgramInstancesTab';
-import { LibraryTab } from '@/components/training-plan/LibraryTab';
+import { MyProgramsScreen } from '@/components/training-plan/MyProgramsScreen';
 
 const TrainingPlan: React.FC = () => {
   return (
     <Routes>
       <Route path="/" element={<TrainingPlanLayout />}>
         <Route index element={<Navigate to="programs" replace />} />
-        <Route path="programs" element={<ProgramsTab />} />
-        <Route path="instances" element={<ProgramInstancesTab />} />
-        <Route path="library" element={<LibraryTab />} />
+        <Route path="programs" element={<MyProgramsScreen />} />
       </Route>
     </Routes>
   );


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Refactor TrainingPlan to a solo experience by removing "Instances" and "Library" tabs and simplifying the "Programs" screen to "My Programs".

---

[Open in Web](https://cursor.com/agents?id=bc-6b069e52-8bf4-4d4b-b99a-d19641073b2d) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-6b069e52-8bf4-4d4b-b99a-d19641073b2d) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)