### PR TITLE
Refactor nutrition logs to solo

### DIFF
--- a/src/components/AppRouter.tsx
+++ b/src/components/AppRouter.tsx
@@ -111,9 +111,10 @@ const AppRouter = () => {
           <Route path="clubs" element={<ClubsScreen />} />
           <Route path="challenges" element={<ChallengesScreen />} />
           <Route path="meets" element={<MeetsScreen />} />
-          <Route path="nutrition-log" element={<Navigate to="/nutrition" replace />} />
-          <Route path="nutrition" element={<NutritionPage />} />
-          <Route path="nutrition/parse" element={<MealParseScreen />} />
+          <Route path="nutrition-log" element={<Navigate to="/nutrition/my-log" replace />} />
+          <Route path="nutrition" element={<Navigate to="/nutrition/my-log" replace />} />
+          <Route path="nutrition/my-log" element={<NutritionPage />} />
+          <Route path="nutrition/my-parse" element={<MealParseScreen />} />
           <Route path="sleep" element={<Navigate to="/analytics" replace />} />
           <Route path="stress" element={<Navigate to="/analytics" replace />} />
           <Route path="analytics" element={<AnalyticsPage />} />

--- a/src/components/nutrition/MealParseScreen.tsx
+++ b/src/components/nutrition/MealParseScreen.tsx
@@ -128,7 +128,7 @@ export const MealParseScreen: React.FC = () => {
       };
 
       await addMeal(mealEntry);
-      navigate('/nutrition', { state: { tab: 'meals' } });
+      navigate('/nutrition/my-log', { state: { tab: 'meals' } });
     } catch (err) {
       console.error('Error saving meal:', err);
       setError('Failed to save meal');
@@ -196,7 +196,7 @@ export const MealParseScreen: React.FC = () => {
           {/* Header */}
           <div className="flex items-center gap-4 mb-6">
             <Button
-              onClick={() => navigate('/nutrition')}
+              onClick={() => navigate('/nutrition/my-log')}
               variant="ghost"
               size="icon"
               className="text-white hover:bg-white/20"
@@ -231,7 +231,7 @@ export const MealParseScreen: React.FC = () => {
           {/* Header */}
           <div className="flex items-center gap-4 mb-6">
             <Button
-              onClick={() => navigate('/nutrition')}
+              onClick={() => navigate('/nutrition/my-log')}
               variant="ghost"
               size="icon"
               className="text-white hover:bg-white/20"
@@ -280,7 +280,7 @@ export const MealParseScreen: React.FC = () => {
         {/* Header */}
         <div className="flex items-center gap-4 mb-6">
           <Button
-            onClick={() => navigate('/nutrition')}
+            onClick={() => navigate('/nutrition/my-log')}
             variant="ghost"
             size="icon"
             className="text-white hover:bg-white/20"

--- a/src/components/nutrition/MealScannerCamera.tsx
+++ b/src/components/nutrition/MealScannerCamera.tsx
@@ -94,7 +94,7 @@ export const MealScannerCamera: React.FC<MealScannerCameraProps> = ({ onClose })
 
   const capturePhoto = () => {
     // Navigate to meal parse screen with photo mode
-    navigate('/nutrition/parse', { state: { mode: 'photo', data: 'photo_data' } });
+    navigate('/nutrition/my-parse', { state: { mode: 'photo', data: 'photo_data' } });
   };
 
   const handleBarcodeScan = async () => {
@@ -103,18 +103,18 @@ export const MealScannerCamera: React.FC<MealScannerCameraProps> = ({ onClose })
       const result = await Barcode.scan();
       
       if (result && result.data) {
-        navigate('/nutrition/parse', { state: { mode: 'barcode', data: result.data } });
+        navigate('/nutrition/my-parse', { state: { mode: 'barcode', data: result.data } });
       }
     } catch (error) {
       console.error('Error scanning barcode:', error);
       // Fallback to mock data for demonstration
-      navigate('/nutrition/parse', { state: { mode: 'barcode', data: '123456789012' } });
+      navigate('/nutrition/my-parse', { state: { mode: 'barcode', data: '123456789012' } });
     }
   };
 
   const handleDescribe = () => {
     // Navigate to meal parse screen with describe mode
-    navigate('/nutrition/parse', { state: { mode: 'describe', data: null } });
+    navigate('/nutrition/my-parse', { state: { mode: 'describe', data: null } });
   };
 
   const modes = [

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -39,7 +39,7 @@ export const NAV_ROUTES: NavItem[] = [
   },
   {
     label: "Nutrition",
-    path: "/nutrition",
+    path: "/nutrition/my-log",
     icon: Activity
   },
   {

--- a/src/constants/navigation.ts
+++ b/src/constants/navigation.ts
@@ -56,7 +56,7 @@ export const soloNavigation = [
   },
   {
     label: 'Nutrition',
-    path: '/nutrition',
+    path: '/nutrition/my-log',
     icon: BookOpen,
   },
   {

--- a/src/pages/Nutrition.tsx
+++ b/src/pages/Nutrition.tsx
@@ -60,9 +60,9 @@ const Nutrition: React.FC = () => {
   return (
     <div className={cn("space-y-6 p-4 md:p-8", contentPadding)}>
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-white mb-2">Nutrition</h1>
+        <h1 className="text-2xl font-bold text-white mb-2">My Nutrition</h1>
         <p className="text-white/70">
-          Track your daily nutrition, log meals, and monitor macro targets
+          Track your personal daily nutrition, log meals, and monitor macro targets
         </p>
       </div>
 


### PR DESCRIPTION
Rename nutrition routes to `/nutrition/my-log` and `/nutrition/my-parse` to align with a solo-focused system.

---

[Open in Web](https://cursor.com/agents?id=bc-6d06e50f-e2c6-4ed5-90d2-a3819c253b06) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-6d06e50f-e2c6-4ed5-90d2-a3819c253b06) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)