### PR TITLE
Fix analytics test types and nutrition slice

### DIFF
--- a/mobile/src/__tests__/analytics.test.ts
+++ b/mobile/src/__tests__/analytics.test.ts
@@ -33,7 +33,7 @@ jest.mock('../config/supabase', () => ({
       eq: jest.fn().mockReturnThis(),
       gte: jest.fn().mockReturnThis(),
       lte: jest.fn().mockReturnThis(),
-      single: jest.fn().mockResolvedValue({ data: null, error: null }),
+      single: jest.fn().mockResolvedValue({ data: null, error: null } as any),
     })),
   },
 }));
@@ -303,7 +303,7 @@ describe('Analytics Services Test Suite', () => {
         { event_name: 'event2', event_properties: {}, timestamp: '2024-01-02' },
       ];
       
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(queuedEvents));
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(JSON.stringify(queuedEvents) as any);
       
       await SupabaseAnalyticsService.syncQueuedEvents();
       

--- a/mobile/src/store/slices/nutritionSlice.ts
+++ b/mobile/src/store/slices/nutritionSlice.ts
@@ -32,7 +32,6 @@ export interface NutritionSlice {
   nutritionGoals: NutritionGoals | null;
   
   // Food search
-  searchResults: Food[];
   searchLoading: boolean;
   searchFilters: FoodSearchFilters;
   selectedFood: Food | null;
@@ -147,7 +146,6 @@ export const createNutritionSlice = (set: any, get: any, api: any): NutritionSli
   todaysFoodLogs: [],
   dailySummary: null,
   nutritionGoals: null,
-  searchResults: [],
   searchLoading: false,
   searchFilters: {},
   selectedFood: null,
@@ -203,7 +201,6 @@ export const createNutritionSlice = (set: any, get: any, api: any): NutritionSli
     try {
       const results = await nutritionService.searchFoods(query, filters);
       set((state: NutritionSlice) => {
-        state.searchResults = results;
         state.searchLoading = false;
       });
     } catch (error: any) {
@@ -215,7 +212,6 @@ export const createNutritionSlice = (set: any, get: any, api: any): NutritionSli
   },
 
   clearSearch: () => set((state: NutritionSlice) => {
-    state.searchResults = [];
     state.searchFilters = {};
     state.selectedFood = null;
   }),
@@ -558,7 +554,6 @@ export const createNutritionSlice = (set: any, get: any, api: any): NutritionSli
       const foods = await nutritionService.searchFoods('', { barcode });
       
       set((state: NutritionSlice) => {
-        state.searchResults = foods;
         state.isLoading = false;
         if (foods.length === 1) {
           state.selectedFood = foods[0];


### PR DESCRIPTION
Fix TypeScript type assertion errors in analytics tests and remove the unused `searchResults` property from the nutrition slice to reduce compilation errors and improve code maintainability.

---
<a href="https://cursor.com/background-agent?bcId=bc-fcd789fa-17fa-41c5-a19d-5acf033808e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fcd789fa-17fa-41c5-a19d-5acf033808e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

